### PR TITLE
fix: correct CMD path in Dockerfile to build/src/index.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ LABEL org.opencontainers.image.title="XRootD MCP Server" \
       org.opencontainers.image.licenses="MIT"
 
 # Run the application
-CMD ["node", "build/index.js"]
+CMD ["node", "build/src/index.js"]


### PR DESCRIPTION
## Problem
The Dockerfile `CMD` referenced `build/index.js`, but TypeScript compiles with `rootDir: "."` and `outDir: "./build"`, so `src/index.ts` outputs to `build/src/index.js`.

This caused the container to fail on startup with `Error: Cannot find module '/app/build/index.js'`.

## Fix
Changed `CMD ["node", "build/index.js"]` → `CMD ["node", "build/src/index.js"]`, matching the `main` field already set in `package.json`.