### PR TITLE
fix: update brace-expansion to address moderate vulnerability (GHSA-f886-m6hf-6m8v)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,11 +449,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }


### PR DESCRIPTION
## Summary

Updates `brace-expansion` to fix a moderate severity vulnerability.

**Advisory**: [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v)
**Severity**: Moderate
**Issue**: Zero-step sequence causes process hang and memory exhaustion

## Changes
- Updated `package-lock.json` via `npm audit fix`

`npm audit` now reports **0 vulnerabilities**.