### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/eic/xrootd-mcp-server/security/code-scanning/1](https://github.com/eic/xrootd-mcp-server/security/code-scanning/1)

In general, the fix is to explicitly add a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scope needed by the workflow. Since this workflow only needs to read repository contents (for `actions/checkout`) and does not perform any write actions against the GitHub API, `contents: read` is sufficient. This can be placed at the root of the workflow (so it applies to all jobs) or under the specific job. Using a root-level block is simpler and future-proof if more jobs are added.

The best minimal change is to add a root-level `permissions` block right after the `name: Test` line. This keeps the job definition unchanged and does not alter any existing functionality. The new block should be:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed; this is a pure configuration change in `.github/workflows/test.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
