### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   verify-container:
     name: Verify Container Image


### PR DESCRIPTION
Potential fix for [https://github.com/eic/xrootd-mcp-server/security/code-scanning/2](https://github.com/eic/xrootd-mcp-server/security/code-scanning/2)

In general, to fix this issue, add a `permissions:` block either at the top level of the workflow (to apply to all jobs) or within the specific job, restricting `GITHUB_TOKEN` to the minimal scopes required. For a workflow that only pulls container images, inspects them, runs containers, and writes to `$GITHUB_STEP_SUMMARY`, no repository write permissions are needed; read access to repository contents is usually sufficient, and even that is only needed if any actions (like checkout) are added later.

The best fix here, without changing functionality, is to add a top-level `permissions:` block after the `on:` section (before `jobs:`) specifying read-only permissions. A minimal, future-proof baseline is:

```yaml
permissions:
  contents: read
```

This will restrict `GITHUB_TOKEN` to read repository contents while preventing unintended writes such as pushing commits or modifying issues. The rest of the workflow remains unchanged. All edits are confined to `.github/workflows/verify-release.yml`, adding a few lines of YAML; no imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
