### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/xrootd.ts
+++ b/src/xrootd.ts
@@ -12,6 +12,20 @@ function encodeXRootDPath(path: string): string {
   return path.split('/').map(segment => encodeURIComponent(segment)).join('/');
 }
 
+// Convert a glob pattern to a RegExp.  All regex metacharacters in the input
+// are escaped so they are treated as literals; only the glob wildcards '*' and
+// '?' retain special meaning (mapping to '.*' and '.' respectively).
+export function globToRegex(glob: string): RegExp {
+  const escapeRegex = (s: string): string =>
+    s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const escapedGlob = escapeRegex(glob)
+    .replace(/\\\*/g, '.*')  // escaped '*' becomes regex '.*'
+    .replace(/\\\?/g, '.');  // escaped '?' becomes regex '.'
+
+  return new RegExp(`^${escapedGlob}$`);
+}
+
 export interface FileInfo {
   path: string;
   size: number;
@@ -331,16 +345,7 @@ export class XRootDClient {
   }
 
   private globToRegex(glob: string): RegExp {
-    // Escape all regex metacharacters so the glob is treated literally,
-    // then translate glob wildcards '*' and '?' to their regex equivalents.
-    const escapeRegex = (s: string): string =>
-      s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-    const escapedGlob = escapeRegex(glob)
-      .replace(/\\\*/g, '.*')  // escaped '*' becomes regex '.*'
-      .replace(/\\\?/g, '.');  // escaped '?' becomes regex '.'
-
-    return new RegExp(`^${escapedGlob}$`);
+    return globToRegex(glob);
   }
 
   // Get directory statistics

--- a/test/glob.test.ts
+++ b/test/glob.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { globToRegex } from '../src/xrootd.js';
+
+describe('globToRegex', () => {
+  describe('glob wildcards', () => {
+    it('* matches any sequence of characters', () => {
+      const re = globToRegex('*.root');
+      assert.ok(re.test('file.root'));
+      assert.ok(re.test('a.b.c.root'));
+      assert.ok(re.test('.root'));
+      assert.ok(!re.test('file.root.extra'));
+    });
+
+    it('? matches exactly one character', () => {
+      const re = globToRegex('file?.txt');
+      assert.ok(re.test('fileA.txt'));
+      assert.ok(re.test('file1.txt'));
+      assert.ok(!re.test('file.txt'));
+      assert.ok(!re.test('fileAB.txt'));
+    });
+
+    it('* and ? can be combined', () => {
+      const re = globToRegex('run?_*.root');
+      assert.ok(re.test('runA_output.root'));
+      assert.ok(re.test('run1_long.name.root'));
+      assert.ok(!re.test('run_output.root'));
+    });
+  });
+
+  describe('literal dot handling', () => {
+    it('. in glob is treated as a literal dot, not a regex wildcard', () => {
+      const re = globToRegex('file.root');
+      assert.ok(re.test('file.root'));
+      assert.ok(!re.test('fileXroot'));
+      assert.ok(!re.test('file_root'));
+    });
+  });
+
+  describe('regex metacharacters are treated as literals', () => {
+    it('+ is treated as a literal plus sign', () => {
+      const re = globToRegex('pi+');
+      assert.ok(re.test('pi+'));
+      assert.ok(!re.test('pi'));
+      assert.ok(!re.test('pii'));
+    });
+
+    it('( and ) are treated as literals', () => {
+      const re = globToRegex('(file)');
+      assert.ok(re.test('(file)'));
+      assert.ok(!re.test('file'));
+    });
+
+    it('| is treated as a literal pipe, not alternation', () => {
+      const re = globToRegex('a|b');
+      assert.ok(re.test('a|b'));
+      assert.ok(!re.test('a'));
+      assert.ok(!re.test('b'));
+    });
+
+    it('$ is treated as a literal dollar sign', () => {
+      const re = globToRegex('price$10');
+      assert.ok(re.test('price$10'));
+      assert.ok(!re.test('price10'));
+    });
+
+    it('^ is treated as a literal caret', () => {
+      const re = globToRegex('^start');
+      assert.ok(re.test('^start'));
+      assert.ok(!re.test('start'));
+    });
+
+    it('{ and } are treated as literals', () => {
+      const re = globToRegex('{a,b}');
+      assert.ok(re.test('{a,b}'));
+      assert.ok(!re.test('a'));
+      assert.ok(!re.test('b'));
+    });
+
+    it('[ and ] are treated as literals, not a character class', () => {
+      const re = globToRegex('[abc]');
+      assert.ok(re.test('[abc]'));
+      assert.ok(!re.test('a'));
+      assert.ok(!re.test('b'));
+      assert.ok(!re.test('c'));
+    });
+
+    it('\\ is treated as a literal backslash', () => {
+      const re = globToRegex('path\\file');
+      assert.ok(re.test('path\\file'));
+      assert.ok(!re.test('pathfile'));
+    });
+  });
+
+  describe('EIC-style filename patterns', () => {
+    it('matches files with = in names using *', () => {
+      const re = globToRegex('run=*.root');
+      assert.ok(re.test('run=123.root'));
+      assert.ok(re.test('run=abc_long.root'));
+      assert.ok(!re.test('run.root'));
+    });
+
+    it('matches files with + literally (e.g. pi+ particle)', () => {
+      const re = globToRegex('pi+_*.root');
+      assert.ok(re.test('pi+_output.root'));
+      assert.ok(!re.test('pi_output.root'));
+      assert.ok(!re.test('pii_output.root'));
+    });
+
+    it('full glob pattern with multiple metacharacters', () => {
+      const re = globToRegex('q2_10$20_*.hepmc3.tree.root');
+      assert.ok(re.test('q2_10$20_00001.hepmc3.tree.root'));
+      // '$' must be literal — strings without it must not match
+      assert.ok(!re.test('q2_1020_00001.hepmc3.tree.root'));
+      assert.ok(!re.test('q2_10X20_00001.hepmc3.tree.root'));
+    });
+  });
+
+  describe('anchoring', () => {
+    it('pattern is anchored to match the full string', () => {
+      const re = globToRegex('*.root');
+      assert.ok(re.test('file.root'));
+      assert.ok(!re.test('file.root.extra'));
+      assert.ok(!re.test('file.root_suffix'));
+    });
+
+    it('empty pattern matches only empty string', () => {
+      const re = globToRegex('');
+      assert.ok(re.test(''));
+      assert.ok(!re.test('a'));
+    });
+  });
+});


### PR DESCRIPTION
Potential fix for <a href="https://github.com/eic/xrootd-mcp-server/security/code-scanning/3">https://github.com/eic/xrootd-mcp-server/security/code-scanning/3</a>

In general, the correct way to fix this is to escape all regex metacharacters in the input string before applying the glob-to-regex transformations. That means first turning any backslashes and other special characters into their escaped literal forms (e.g. `\` → `\\`, `+` → `\+`, `(` → `\(`, etc.), and only then replacing the glob wildcards (`*` and `?`) with their corresponding regex fragments (`.*` and `.`). This ensures that user-supplied literal characters cannot accidentally (or maliciously) alter the structure of the resulting regular expression.

The best targeted fix here is to add a small helper inside `globToRegex` that escapes all regex metacharacters, call it on `glob`, and then perform the `*`/`?` translations on the already-escaped string. We can also remove the existing `.replace(/\./g, '\\.')` because escaping `.` will now be handled by the general helper. Concretely, inside `globToRegex` (around lines 333–339 in `src/xrootd.ts`), define a local function `escapeRegex` that uses a single `.replace` with a character class that includes all regex metacharacters, including backslash. Then compute `escapedGlob = escapeRegex(glob)` and apply `.replace(/\*/g, '.*')` and `.replace(/\?/g, '.')` to that. Finally, use `escapedGlob` in the `new RegExp` call as before. No new imports are required.

## Additional Changes

- **Testability**: `globToRegex` has been extracted from a private class method into a standalone exported function in `src/xrootd.ts` (the private method now delegates to it), making it directly unit-testable without requiring a live XRootD server.
- **Unit tests**: Added `test/glob.test.ts` with 17 unit tests covering glob wildcards (`*`, `?`), literal dot handling, all regex metacharacters treated as literals (`+`, `(`, `)`, `|`, `$`, `^`, `{`, `}`, `[`, `]`, `\`), EIC-style filename patterns (e.g. `pi+`, `run=*.root`), and anchoring behavior. These tests lock in the escaping fix and guard against regressions.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/eic/xrootd-mcp-server/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
