### PR TITLE
fix: remove tty: true to allow containers to exit on stdin close

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: ghcr.io/eic/xrootd-mcp-server:latest
     container_name: xrootd-mcp-server
     stdin_open: true
-    tty: true
     environment:
       # Required: XRootD server URL
       XROOTD_SERVER: ${XROOTD_SERVER:-root://dtn-eic.jlab.org}


### PR DESCRIPTION
## Problem

When using the MCP server via `docker compose run --rm`, multiple containers accumulate and are never cleaned up:

```
CONTAINER ID   IMAGE                                   STATUS
7589f08f965e   ghcr.io/eic/xrootd-mcp-server:latest   Up 34 minutes
82e5f71df257   ghcr.io/eic/xrootd-mcp-server:latest   Up 2 hours
7e667b4722e3   ghcr.io/eic/xrootd-mcp-server:latest   Up 2 hours
...
```

## Root Cause

`tty: true` in `docker-compose.yml` allocates a pseudo-TTY, which does not propagate EOF when the parent process closes stdin. As a result, the container never exits and the `--rm` flag never triggers cleanup.

## Fix

Remove `tty: true`. For stdio-based MCP servers, only `stdin_open: true` is needed. Without a TTY, the container correctly detects stdin closing and exits, allowing `--rm` to clean it up automatically.