### PR TITLE
Add HTTP/SSE transport (+ build-from-source fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ WORKDIR /app
 # Copy package files
 COPY package*.json tsconfig.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies. --ignore-scripts skips the `prepare` hook, which would
+# run the build before the sources are copied in.
+RUN npm ci --ignore-scripts
 
 # Copy source code
 COPY src/ ./src/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc && chmod +x build/src/index.js",
     "watch": "tsc --watch",
     "prepack": "npm run build",
+    "prepare": "npm run build",
     "test": "npm run build && node --test build/test/*.test.js",
     "test:integration": "npm run test",
     "test:coverage": "npm run build && c8 --reporter=text --reporter=lcov --reporter=json-summary node --test build/test/*.test.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "xrootd-mcp-server": "./build/src/index.js"
   },
   "scripts": {
-    "build": "npm exec --no -- tsc && chmod +x build/src/index.js",
+    "build": "npm exec --no -- tsc && node -e \"require('fs').chmodSync('build/src/index.js', 0o755)\"",
     "watch": "npm exec --no -- tsc --watch",
     "prepack": "npm run build",
     "prepare": "npm run build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { createServer as createHttpServer, IncomingMessage, ServerResponse } from 'node:http';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -196,17 +198,8 @@ function getClient(serverName?: string): ServerEntry {
   return servers.values().next().value as ServerEntry;
 }
 
-const server = new Server(
-  {
-    name: 'xrootd-mcp-server',
-    version: '0.1.0',
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  }
-);
+// The MCP Server is created per connection in createServer() (see below),
+// so concurrent SSE clients each get their own Server instance.
 
 // Log server info for debugging
 console.error(`Server: xrootd-mcp-server v0.1.0`);
@@ -644,7 +637,13 @@ const tools: Tool[] = [
   },
 ];
 
-server.setRequestHandler(ListToolsRequestSchema, async () => {
+function createServer(): Server {
+  const server = new Server(
+    { name: 'xrootd-mcp-server', version: '0.1.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
   return { tools };
 });
 
@@ -1135,6 +1134,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
+  return server;
+}
+
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 Bytes';
   
@@ -1145,15 +1147,84 @@ function formatBytes(bytes: number): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }
 
-async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  
-  console.error('XRootD MCP Server running on stdio');
+function logServerSummary() {
   console.error(`Configured servers: ${Array.from(servers.keys()).join(', ')}`);
   for (const [srvName, { client }] of servers.entries()) {
     const stats = client.getCacheStats();
     console.error(`  [${srvName}] cache entries: ${stats.size}`);
+  }
+}
+
+async function runStdio() {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error('XRootD MCP Server running on stdio');
+  logServerSummary();
+}
+
+async function runSse() {
+  const host = process.env.MCP_HOST || '127.0.0.1';
+  const port = parseInt(process.env.MCP_PORT || '9102', 10);
+
+  // Active SSE sessions keyed by transport.sessionId.
+  const transports = new Map<string, SSEServerTransport>();
+
+  const httpServer = createHttpServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url || '/', `http://${host}:${port}`);
+
+    if (req.method === 'GET' && url.pathname === '/sse') {
+      const transport = new SSEServerTransport('/messages', res);
+      const server = createServer();
+      transports.set(transport.sessionId, transport);
+      res.on('close', () => {
+        transports.delete(transport.sessionId);
+      });
+      try {
+        await server.connect(transport);
+      } catch (error: any) {
+        console.error('Error establishing SSE connection:', error?.message ?? error);
+        transports.delete(transport.sessionId);
+      }
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/messages') {
+      const sessionId = url.searchParams.get('sessionId');
+      const transport = sessionId ? transports.get(sessionId) : undefined;
+      if (!transport) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('No transport found for sessionId');
+        return;
+      }
+      await transport.handlePostMessage(req, res);
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(port, host, () => {
+      httpServer.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  console.error(`XRootD MCP Server running on SSE at http://${host}:${port}/sse`);
+  logServerSummary();
+}
+
+async function main() {
+  const transportMode = (process.env.MCP_TRANSPORT || 'stdio').trim().toLowerCase();
+
+  if (transportMode === 'sse') {
+    await runSse();
+  } else {
+    await runStdio();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1164,15 +1164,31 @@ async function runStdio() {
   logServerSummary();
 }
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
 async function runSse() {
   const host = process.env.MCP_HOST || '127.0.0.1';
-  const port = parseInt(process.env.MCP_PORT || '9102', 10);
+  const portEnv = process.env.MCP_PORT?.trim();
+  const port = portEnv ? Number(portEnv) : 9102;
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`MCP_PORT must be an integer between 1 and 65535, got '${portEnv}'`);
+  }
 
   // Active SSE sessions keyed by transport.sessionId.
   const transports = new Map<string, SSEServerTransport>();
 
   const httpServer = createHttpServer(async (req: IncomingMessage, res: ServerResponse) => {
-    const url = new URL(req.url || '/', `http://${host}:${port}`);
+    // A fixed base keeps parsing independent of the bind address (IPv6 hosts
+    // would need brackets) and of malformed request targets.
+    let url: URL;
+    try {
+      url = new URL(req.url || '/', 'http://localhost');
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Bad request');
+      return;
+    }
 
     if (req.method === 'GET' && url.pathname === '/sse') {
       const transport = new SSEServerTransport('/messages', res);
@@ -1198,7 +1214,17 @@ async function runSse() {
         res.end('No transport found for sessionId');
         return;
       }
-      await transport.handlePostMessage(req, res);
+      try {
+        await transport.handlePostMessage(req, res);
+      } catch (error: any) {
+        console.error('Error handling message:', error?.message ?? error);
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+        }
+        if (!res.writableEnded) {
+          res.end('Internal server error');
+        }
+      }
       return;
     }
 
@@ -1215,6 +1241,13 @@ async function runSse() {
   });
 
   console.error(`XRootD MCP Server running on SSE at http://${host}:${port}/sse`);
+  if (!LOOPBACK_HOSTS.has(host)) {
+    console.error(
+      `WARNING: MCP_HOST=${host} exposes the full tool surface on a non-loopback ` +
+        'interface with no authentication. Bind to 127.0.0.1 and use a tunnel or an ' +
+        'authenticating proxy for remote access.'
+    );
+  }
   logServerSummary();
 }
 

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer } from 'node:net';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+// The tool surface is registered without contacting XRootD, so this smoke test
+// needs no live store -- only a syntactically valid server URL.
+const TEST_SERVER = 'root://sse-smoke-test.invalid';
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+function waitForListening(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('server did not start within 15s')), 15000);
+    child.stderr?.on('data', (chunk: Buffer) => {
+      if (chunk.toString().includes('running on SSE')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited early with code ${code}`));
+    });
+  });
+}
+
+describe('SSE transport', () => {
+  let child: ChildProcess;
+  let client: Client;
+  let port: number;
+
+  before(async () => {
+    port = await freePort();
+    child = spawn(process.execPath, ['build/src/index.js'], {
+      env: {
+        ...process.env,
+        MCP_TRANSPORT: 'sse',
+        MCP_HOST: '127.0.0.1',
+        MCP_PORT: String(port),
+        XROOTD_SERVER: TEST_SERVER,
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    await waitForListening(child);
+
+    client = new Client({ name: 'sse-test-client', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`)));
+  });
+
+  after(async () => {
+    await client?.close();
+    child?.kill();
+  });
+
+  it('should list tools over SSE', async () => {
+    const tools = await client.listTools();
+    const toolNames = (tools.tools as Tool[]).map((t) => t.name);
+
+    assert.ok(tools.tools.length > 0);
+    assert.ok(toolNames.includes('list_directory'));
+  });
+
+  it('should serve a second concurrent client', async () => {
+    const second = new Client({ name: 'sse-test-client-2', version: '1.0.0' }, { capabilities: {} });
+    await second.connect(new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`)));
+
+    try {
+      const tools = await second.listTools();
+      assert.ok(tools.tools.length > 0);
+    } finally {
+      await second.close();
+    }
+  });
+
+  it('should reject a POST with an unknown sessionId', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/messages?sessionId=does-not-exist`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('should return 404 for unknown paths', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/nope`);
+
+    assert.strictEqual(response.status, 404);
+  });
+});


### PR DESCRIPTION
## What

Adds an **HTTP/SSE transport** to `xrootd-mcp-server` (default stays `stdio`), so it can run as a
networked MCP service (e.g. behind an `eic-mcp` launcher inside eic-shell), and fixes a
build-from-source packaging gap.

## Changes

**1. SSE transport** (`src/index.ts`) — selected by env, defaulting to `stdio`:

```bash
MCP_TRANSPORT=sse MCP_HOST=127.0.0.1 MCP_PORT=9102 node build/src/index.js
#   GET  /sse                        (event stream)
#   POST /messages?sessionId=<id>    (client → server)
```

The MCP `Server` is now created **per connection** (a `createServer()` factory) instead of a single
global instance, so multiple concurrent SSE clients each get their own `Server`. The SDK's
`Protocol.connect()` throws *"Already connected to a transport"* on a second `connect()` to a shared
`Server`, which would otherwise leave a second SSE client with a dead stream. `stdio` behaviour is
unchanged.

**2. Build from source** (`package.json`) — add `"prepare": "npm run build"`.

The package declared a `prepack` hook (which runs only on `npm pack`/publish) but no `prepare`, so
`npm install` from source (Spack, git installs, `npm install <dir>`) never compiled the TypeScript —
leaving no `build/src/index.js` and a non-runnable package. `prepare` runs on install-from-source.

## Test

- `npm install && npm run build` compiles cleanly.
- **stdio**: unchanged.
- **SSE, single client**: `list_directory` etc. return live results from a JLab XRootD store.
- **SSE, two concurrent clients**: both `initialize` + `list_tools` succeed (18 tools each); before
  this change the second client dead-streamed.
- **Install-from-source**: with `prepare`, a fresh `npm install` produces `build/src/index.js`.

## Note

This also unblocks the Spack/container packaging: `eic_xl` currently installs the source but never
builds it, so `/opt/local/bin/xrootd-mcp-server` has no entry point. The same `prepare` gap likely
affects `zenodo-mcp-server`.
